### PR TITLE
Add older IE support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,8 +1,11 @@
-<html><head>
-    <!-- Original test page written by Dominic Mazzoni -->
-    <title>focus-ring class demo</title>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <style>
+    <title>Focus Ring</title>
+	<style>
       div,input,textarea,h1,h2 {
       font-family: arial, sans-serif;
       }
@@ -21,14 +24,14 @@
       width: 10em;
       }
     </style>
+	<style>
+		:focus:not(.focus-ring) {
+			outline: none;
+		}
+	</style>
     <script src="../src/focus-ring.js"></script>
-    <style>
-        :focus:not(.focus-ring) {
-          outline: none;
-        }
-    </style>
-  </head>
-  <body>
+</head>
+<body>
     <h1>Keyboard-only focus test</h1>
     <p>
       This page contains various html controls and demonstrates a proposal for only drawing a focus ring when the keyboard is being used.
@@ -36,7 +39,7 @@
     </p>
     <h2>Editable text</h2>
     <div>
-      <input placeholder="Single line">
+      <input type="text" placeholder="Single line">
     </div>
     <div>
       <textarea placeholder="Multi line"></textarea>
@@ -106,7 +109,5 @@
     <div>
       <input type="file" title="File">
     </div>
-
-
-  </body>
+</body>
 </html>

--- a/src/focus-ring.js
+++ b/src/focus-ring.js
@@ -1,6 +1,8 @@
 /* https://github.com/WICG/focus-ring */
 document.addEventListener('DOMContentLoaded', function() {
     var hadKeyboardEvent = false,
+        focusRingClass = 'focus-ring',
+        focusRingAttr = 'data-focus-ring-added',
         keyboardModalityWhitelist = [ 'input:not([type])',
                                       'input[type=text]',
                                       'input[type=number]',
@@ -29,22 +31,31 @@ document.addEventListener('DOMContentLoaded', function() {
 	    }
 	    return triggers;
 	},
+        _addClass = function(el, htmlClass) {
+            el.className += ' '+htmlClass;   
+        },
+        _removeClass = function(el, htmlClass) {
+            var elClass = ' '+el.className+' ';
+            while(elClass.indexOf(' '+htmlClass+' ') != -1)
+                elClass = elClass.replace(' '+htmlClass+' ', '');
+            el.className = elClass;
+        },
         addFocusRingClass = function(el) {
-            if (el.classList.contains('focus-ring'))
+            if (el.className.indexOf(focusRingClass) != -1)
                 return;
-            el.classList.add('focus-ring');
-            el.setAttribute('data-focus-ring-added', '');
+            _addClass(el,focusRingClass);
+            el.setAttribute(focusRingAttr, '');
         },
         removeFocusRingClass = function(el) {
-            if (!el.hasAttribute('data-focus-ring-added'))
+            if (!el.hasAttribute(focusRingAttr))
                 return;
-            el.classList.remove('focus-ring');
-            el.removeAttribute('data-focus-ring-added')
+            _removeClass(el,focusRingClass);
+            el.removeAttribute(focusRingAttr)
         };
 
     document.body.addEventListener('keydown', function() {
         hadKeyboardEvent = true;
-        if (document.activeElement.matches(':focus')) {
+        if (document.activeElement) {
             addFocusRingClass(document.activeElement);
         }
         if (isHandlingKeyboardThrottle) {

--- a/src/focus-ring.js
+++ b/src/focus-ring.js
@@ -35,19 +35,14 @@ document.addEventListener('DOMContentLoaded', function() {
     regExp = function(name) {
 	    return new RegExp('(^| )'+ name +'( |$)');
     },
-    forEach = function(list, fn, scope) {
-        for (var i = 0; i < list.length; i++) {
-            fn.call(scope, list[i]);
-        }
-    },
     addClass = function(el, htmlClass) {
         el.className += ' '+htmlClass;
     },
     removeClass = function(el, htmlClass) {
-        forEach(el, function(htmlClass) {
-            this.element.className =
-                this.element.className.replace(regExp(name), '');
-        }, this);
+        var elClass = ' '+el.className+' ';
+        while(elClass.indexOf(' '+htmlClass+' ') != -1)
+            elClass = elClass.replace(regExp(htmlClass), '');
+        el.className = elClass;
     },
     addFocusRingClass = function(el) {
         if (el.className.indexOf(focusRingClass) != -1)

--- a/src/focus-ring.js
+++ b/src/focus-ring.js
@@ -31,31 +31,39 @@ document.addEventListener('DOMContentLoaded', function() {
 	    }
 	    return triggers;
 	},
-        _addClass = function(el, htmlClass) {
-            el.className += ' '+htmlClass;   
-        },
-        _removeClass = function(el, htmlClass) {
-            var elClass = ' '+el.className+' ';
-            while(elClass.indexOf(' '+htmlClass+' ') != -1)
-                elClass = elClass.replace(' '+htmlClass+' ', '');
-            el.className = elClass;
-        },
-        addFocusRingClass = function(el) {
-            if (el.className.indexOf(focusRingClass) != -1)
-                return;
-            _addClass(el,focusRingClass);
-            el.setAttribute(focusRingAttr, '');
-        },
-        removeFocusRingClass = function(el) {
-            if (!el.hasAttribute(focusRingAttr))
-                return;
-            _removeClass(el,focusRingClass);
-            el.removeAttribute(focusRingAttr)
-        };
-
+    // https://developer.mozilla.org/en-US/docs/Web/API/Element/classList#Polyfill
+    regExp = function(name) {
+	    return new RegExp('(^| )'+ name +'( |$)');
+    },
+    forEach = function(list, fn, scope) {
+        for (var i = 0; i < list.length; i++) {
+            fn.call(scope, list[i]);
+        }
+    },
+    addClass = function(el, htmlClass) {
+        el.className += ' '+htmlClass;
+    },
+    removeClass = function(el, htmlClass) {
+        forEach(el, function(htmlClass) {
+            this.element.className =
+                this.element.className.replace(regExp(name), '');
+        }, this);
+    },
+    addFocusRingClass = function(el) {
+        if (el.className.indexOf(focusRingClass) != -1)
+            return;
+        addClass(el,focusRingClass);
+        el.setAttribute(focusRingAttr, '');
+    },
+    removeFocusRingClass = function(el) {
+        if (!el.hasAttribute(focusRingAttr))
+            return;
+        removeClass(el,focusRingClass);
+        el.removeAttribute(focusRingAttr)
+    };
     document.body.addEventListener('keydown', function() {
         hadKeyboardEvent = true;
-        if (document.activeElement) {
+        if (document.activeElement && document.activeElement !== document.body) {
             addFocusRingClass(document.activeElement);
         }
         if (isHandlingKeyboardThrottle) {
@@ -65,13 +73,11 @@ document.addEventListener('DOMContentLoaded', function() {
             hadKeyboardEvent = false;
         }, 100);
     }, true);
-
     document.body.addEventListener('focus', function(e) {
         if (!hadKeyboardEvent && !focusTriggersKeyboardModality(e.target))
             return;
         addFocusRingClass(e.target);
     }, true);
-
     document.body.addEventListener('blur', function(e) {
         removeFocusRingClass(e.target)
     }, true);


### PR DESCRIPTION
Hi :)

I've tweaked the Polyfill to reach back a bit further with IE.

1. Added `.gitignore` file
2. Defined HTML class and attribute as var: `focus-ring`, `data-focus-ring-added`
2. Went with `indexOf()` instead of `.contains('focus-ring')`
2. Created `_addClass()` & `_removeClass()` helper functions to replace `el.classList.add()` & `el.classList.remove()`
3. Killed the `.matches(':focus')` method on line 58 -- no old IE support and felt redundant.
4. Cleaned up HTML in demo.. something in there was causing old IE to freak out. Added doctype, and IE meta.
