### PR TITLE
Add old IE support

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -1,6 +1,9 @@
-<html><head>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <!-- Original test page written by Dominic Mazzoni -->
-    <title>focus-ring class demo</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <style>
       div,input,textarea,h1,h2 {

--- a/src/focus-ring.js
+++ b/src/focus-ring.js
@@ -5,6 +5,7 @@ document.addEventListener('DOMContentLoaded', function() {
         keyboardThrottleTimeoutID = 0,
         focusRingClass = 'focus-ring',
         focusRingAttr = 'data-focus-ring-added',
+        matchClassRegEx = regExp(focusRingClass),
 
         // These elements should always have a focus ring drawn, because they are
         // associated with switching to a keyboard modality.
@@ -47,7 +48,7 @@ document.addEventListener('DOMContentLoaded', function() {
      * @return {string}
      */
     function regExp(name) {
-	    return new RegExp('(^| )'+ name +'( |$)');
+	    return new RegExp('(^|\\W)'+name+'($|\\W)', 'gi');
     }
 
     /**
@@ -72,8 +73,9 @@ document.addEventListener('DOMContentLoaded', function() {
      * @param {Element} el
      */
     function addFocusRingClass(el) {
-        if (el.className.indexOf(focusRingClass) != -1)
+		if(matchClassRegEx.test(el.className)) {
             return;
+        }
         if (el.className !== '') {
             el.className += ' '+focusRingClass;
         } else {
@@ -88,11 +90,13 @@ document.addEventListener('DOMContentLoaded', function() {
      * @param {Element} el
      */
     function removeFocusRingClass(el) {
-        if (!el.hasAttribute(focusRingAttr))
+        if (!el.hasAttribute(focusRingAttr)){
             return;
+        }
         var elClass = el.className;
-        while(elClass.indexOf(focusRingClass) != -1)
-            elClass = elClass.replace(regExp(focusRingClass), '');
+        while(elClass.indexOf(focusRingClass) != -1){
+            elClass = elClass.replace(matchClassRegEx, '');
+        }
         el.className = elClass;
         el.removeAttribute(focusRingAttr)
     }

--- a/src/focus-ring.js
+++ b/src/focus-ring.js
@@ -1,11 +1,14 @@
 /* https://github.com/WICG/focus-ring */
 document.addEventListener('DOMContentLoaded', function() {
-    var hadKeyboardEvent = false;
-    var keyboardThrottleTimeoutID = 0;
 
-    // These elements should always have a focus ring drawn, because they are
-    // associated with switching to a keyboard modality.
-    var keyboardModalityWhitelist = [ 'input:not([type])',
+    var hadKeyboardEvent = false,
+        keyboardThrottleTimeoutID = 0,
+        focusRingClass = 'focus-ring',
+        focusRingAttr = 'data-focus-ring-added',
+
+        // These elements should always have a focus ring drawn, because they are
+        // associated with switching to a keyboard modality.
+        keyboardModalityWhitelist = [ 'input:not([type])',
                                       'input[type=text]',
                                       'input[type=search]',
                                       'input[type=url]',
@@ -59,10 +62,10 @@ document.addEventListener('DOMContentLoaded', function() {
      * @param {Element} el
      */
     function addFocusRingClass(el) {
-        if (el.classList.contains('focus-ring'))
+        if (el.classList.contains(focusRingClass))
             return;
-        el.classList.add('focus-ring');
-        el.setAttribute('data-focus-ring-added', '');
+        el.classList.add(focusRingClass);
+        el.setAttribute(focusRingAttr, '');
     }
 
     /**
@@ -71,10 +74,10 @@ document.addEventListener('DOMContentLoaded', function() {
      * @param {Element} el
      */
     function removeFocusRingClass(el) {
-        if (!el.hasAttribute('data-focus-ring-added'))
+        if (!el.hasAttribute(focusRingAttr))
             return;
-        el.classList.remove('focus-ring');
-        el.removeAttribute('data-focus-ring-added')
+        el.classList.remove(focusRingClass);
+        el.removeAttribute(focusRingAttr)
     }
 
     /**

--- a/src/focus-ring.js
+++ b/src/focus-ring.js
@@ -45,7 +45,6 @@ document.addEventListener('DOMContentLoaded', function() {
      * https://developer.mozilla.org/en-US/docs/Web/API/Element/classList#Polyfill
      * @param {Element} name
      * @return {string}
-     * https://developer.mozilla.org/en-US/docs/Web/API/Element/classList#Polyfill
      */
     function regExp(name) {
 	    return new RegExp('(^| )'+ name +'( |$)');

--- a/src/focus-ring.js
+++ b/src/focus-ring.js
@@ -41,6 +41,17 @@ document.addEventListener('DOMContentLoaded', function() {
     }());
 
     /**
+     * Regex helper function.
+     * https://developer.mozilla.org/en-US/docs/Web/API/Element/classList#Polyfill
+     * @param {Element} name
+     * @return {string}
+     * https://developer.mozilla.org/en-US/docs/Web/API/Element/classList#Polyfill
+     */
+    function regExp(name) {
+	    return new RegExp('(^| )'+ name +'( |$)');
+    }
+
+    /**
      * Computes whether the given element should automatically trigger the
      * `focus-ring` class being added, i.e. whether it should always match
      * `:focus-ring` when focused.
@@ -62,9 +73,13 @@ document.addEventListener('DOMContentLoaded', function() {
      * @param {Element} el
      */
     function addFocusRingClass(el) {
-        if (el.classList.contains(focusRingClass))
+        if (el.className.indexOf(focusRingClass) != -1)
             return;
-        el.classList.add(focusRingClass);
+        if (el.className !== '') {
+            el.className += ' '+focusRingClass;
+        } else {
+            el.className = focusRingClass;
+        }
         el.setAttribute(focusRingAttr, '');
     }
 
@@ -76,7 +91,10 @@ document.addEventListener('DOMContentLoaded', function() {
     function removeFocusRingClass(el) {
         if (!el.hasAttribute(focusRingAttr))
             return;
-        el.classList.remove(focusRingClass);
+        var elClass = el.className;
+        while(elClass.indexOf(focusRingClass) != -1)
+            elClass = elClass.replace(regExp(focusRingClass), '');
+        el.className = elClass;
         el.removeAttribute(focusRingAttr)
     }
 


### PR DESCRIPTION
Here's a PR to support for older versions of IE.

- Adding support for older versions of IE that don't support `classList`
- Borrowed regex helper from [classlist Polyfil](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList#Polyfill)
- Cleaned up demo HTML