### PR TITLE
Fix Element.matches()'s selectorString syntax

### DIFF
--- a/src/focus-ring.js
+++ b/src/focus-ring.js
@@ -49,7 +49,7 @@ document.addEventListener('DOMContentLoaded', function() {
      */
     function focusTriggersKeyboardModality(el) {
         return matchesFunction.call(el, keyboardModalityWhitelist) &&
-            matchesFunction.call(el, ':not([readonly]');
+            matchesFunction.call(el, ':not([readonly])');
     }
 
     /**


### PR DESCRIPTION
This fixes a typo in not closing the `:not()` pseudo-class in the
selectorString.