### PR TITLE
Fix issue number #33

### DIFF
--- a/dist/focus-ring.js
+++ b/dist/focus-ring.js
@@ -261,6 +261,9 @@ document.addEventListener('DOMContentLoaded', function() {
    * @param {Event} e
    */
   function onFocus(e) {
+    if (e.target == document)
+      return;
+
     if (hadKeyboardEvent || focusTriggersKeyboardModality(e.target)) {
       addFocusRingClass(e.target);
       hadKeyboardEvent = false;
@@ -272,6 +275,9 @@ document.addEventListener('DOMContentLoaded', function() {
    * @param {Event} e
    */
   function onBlur(e) {
+    if (e.target == document)
+      return;
+
     removeFocusRingClass(e.target);
   }
 

--- a/dist/focus-ring.js
+++ b/dist/focus-ring.js
@@ -199,19 +199,16 @@ document.addEventListener('DOMContentLoaded', function() {
    */
   function focusTriggersKeyboardModality(el) {
     var type = el.type;
-    var tagName = el.tagName.toLowerCase();
+    var tagName = el.tagName;
 
-    if (tagName == 'input' && inputTypesWhitelist[type] && !el.readonly) {
+    if (tagName == 'INPUT' && inputTypesWhitelist[type] && !el.readonly)
       return true;
-    }
 
-    if (tagName == 'textarea' && !el.readonly) {
+    if (tagName == 'TEXTAREA' && !el.readonly)
       return true;
-    }
 
-    if (el.getAttribute('role').toLowerCase() == 'textbox') {
+    if (el.getAttribute('role').toLowerCase() == 'textbox')
       return true;
-    }
 
     return false;
   }
@@ -225,6 +222,7 @@ document.addEventListener('DOMContentLoaded', function() {
     if (index(el).contains('focus-ring'))
       return;
     index(el).add('focus-ring');
+    el.setAttribute('data-focus-ring-added', '');
     // Keep a reference to the element to which the focus-ring class is applied
     // so the focus-ring class can be restored to it if the window regains
     // focus after being blurred.
@@ -237,32 +235,29 @@ document.addEventListener('DOMContentLoaded', function() {
    * @param {Element} el
    */
   function removeFocusRingClass(el) {
+    if (!el.hasAttribute('data-focus-ring-added'))
+      return;
     index(el).remove('focus-ring');
+    el.removeAttribute('data-focus-ring-added');
   }
 
   /**
-   * On `keydown`, set `hadKeyboardEvent`, to be removed 100ms later if there
-   * are no further keyboard events.  The 100ms throttle handles cases where
-   * focus is redirected programmatically after a keyboard event, such as
-   * opening a menu or dialog.
+   * On `keydown`, set `hadKeyboardEvent`, add `focus-ring` class if the
+   * key was Tab.
    * @param {Event} e
    */
   function onKeyDown(e) {
     if (e.altKey || e.ctrlKey || e.metaKey)
       return;
 
-    var isTabKey = e.keyCode == 9;
-    var isTabNavigation = isTabKey || isTabKey && e.shiftKey;
-
-    if (!isTabNavigation)
+    if (e.keyCode != 9)
       return;
 
     // `activeElement` defaults to document.body if nothing focused,
     // so check the active element is actually focused.
     var activeElement = document.activeElement;
-    if (activeElement.tagName == 'body') {
+    if (activeElement.tagName == 'BODY')
       return;
-    }
 
     addFocusRingClass(activeElement);
     hadKeyboardEvent = true;
@@ -270,16 +265,16 @@ document.addEventListener('DOMContentLoaded', function() {
 
   /**
    * On `focus`, add the `focus-ring` class to the target if:
-   * - a keydown event preceded the focus event, meaning the target received
-   *   focus as a result of keyboard navigation.
+   * - the target received focus as a result of keyboard navigation
    * - the event target is an element that will likely require interaction
    *   via the keyboard (e.g. a text box)
    * @param {Event} e
    */
   function onFocus(e) {
-    if (hadKeyboardEvent || focusTriggersKeyboardModality(e.target))
+    if (hadKeyboardEvent || focusTriggersKeyboardModality(e.target)) {
       addFocusRingClass(e.target);
       hadKeyboardEvent = false;
+    }
   }
 
   /**
@@ -295,9 +290,8 @@ document.addEventListener('DOMContentLoaded', function() {
    * to which it was previously applied.
    */
   function onWindowFocus() {
-    if (document.activeElement == elWithFocusRing) {
+    if (document.activeElement == elWithFocusRing)
       addFocusRingClass(elWithFocusRing);
-    }
   }
 
   document.addEventListener('keydown', onKeyDown, true);

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "rollup-watch": "^3.2.2"
   },
   "dependencies": {
-    "dom-classlist": "^1.0.1",
-    "dom-matches": "^2.0.0"
+    "dom-classlist": "^1.0.1"
   }
 }

--- a/src/focus-ring.js
+++ b/src/focus-ring.js
@@ -31,17 +31,14 @@ document.addEventListener('DOMContentLoaded', function() {
     var type = el.type;
     var tagName = el.tagName.toLowerCase();
 
-    if (tagName == 'input' && inputTypesWhitelist[type] && !el.readonly) {
+    if (tagName == 'input' && inputTypesWhitelist[type] && !el.readonly)
       return true;
-    }
 
-    if (tagName == 'textarea' && !el.readonly) {
+    if (tagName == 'textarea' && !el.readonly)
       return true;
-    }
 
-    if (el.getAttribute('role').toLowerCase() == 'textbox') {
+    if (el.getAttribute('role').toLowerCase() == 'textbox')
       return true;
-    }
 
     return false;
   }
@@ -52,9 +49,8 @@ document.addEventListener('DOMContentLoaded', function() {
    * @param {Element} el
    */
   function addFocusRingClass(el) {
-    if (classList(el).contains('focus-ring')) {
+    if (classList(el).contains('focus-ring'))
       return;
-    }
 
     classList(el).add('focus-ring');
     // Keep a reference to the element to which the focus-ring class is applied
@@ -80,20 +76,17 @@ document.addEventListener('DOMContentLoaded', function() {
    * @param {Event} e
    */
   function onKeyDown(e) {
-    if (e.altKey || e.ctrlKey || e.metaKey) {
+    if (e.altKey || e.ctrlKey || e.metaKey)
       return;
-    }
 
-    if (e.keyCode != 9) {
+    if (e.keyCode != 9)
       return;
-    }
 
     // `activeElement` defaults to document.body if nothing focused,
     // so check the active element is actually focused.
     var activeElement = document.activeElement;
-    if (activeElement.tagName == 'body') {
+    if (activeElement.tagName == 'body')
       return;
-    }
 
     addFocusRingClass(activeElement);
     hadKeyboardEvent = true;
@@ -126,9 +119,8 @@ document.addEventListener('DOMContentLoaded', function() {
    * to which it was previously applied.
    */
   function onWindowFocus() {
-    if (document.activeElement == elWithFocusRing) {
+    if (document.activeElement == elWithFocusRing)
       addFocusRingClass(elWithFocusRing);
-    }
   }
 
   document.addEventListener('keydown', onKeyDown, true);

--- a/src/focus-ring.js
+++ b/src/focus-ring.js
@@ -52,8 +52,10 @@ document.addEventListener('DOMContentLoaded', function() {
    * @param {Element} el
    */
   function addFocusRingClass(el) {
-    if (classList(el).contains('focus-ring'))
+    if (classList(el).contains('focus-ring')) {
       return;
+    }
+
     classList(el).add('focus-ring');
     // Keep a reference to the element to which the focus-ring class is applied
     // so the focus-ring class can be restored to it if the window regains
@@ -78,14 +80,13 @@ document.addEventListener('DOMContentLoaded', function() {
    * @param {Event} e
    */
   function onKeyDown(e) {
-    if (e.altKey || e.ctrlKey || e.metaKey)
+    if (e.altKey || e.ctrlKey || e.metaKey) {
       return;
+    }
 
-    var isTabKey = e.keyCode == 9;
-    var isTabNavigation = isTabKey || isTabKey && e.shiftKey;
-
-    if (!isTabNavigation)
+    if (e.keyCode != 9) {
       return;
+    }
 
     // `activeElement` defaults to document.body if nothing focused,
     // so check the active element is actually focused.
@@ -100,16 +101,16 @@ document.addEventListener('DOMContentLoaded', function() {
 
   /**
    * On `focus`, add the `focus-ring` class to the target if:
-   * - a keydown event preceded the focus event, meaning the target received
-   *   focus as a result of keyboard navigation.
+   * - the target received focus as a result of keyboard navigation
    * - the event target is an element that will likely require interaction
    *   via the keyboard (e.g. a text box)
    * @param {Event} e
    */
   function onFocus(e) {
-    if (hadKeyboardEvent || focusTriggersKeyboardModality(e.target))
+    if (hadKeyboardEvent || focusTriggersKeyboardModality(e.target)) {
       addFocusRingClass(e.target);
       hadKeyboardEvent = false;
+    }
   }
 
   /**

--- a/src/focus-ring.js
+++ b/src/focus-ring.js
@@ -51,8 +51,8 @@ document.addEventListener('DOMContentLoaded', function() {
   function addFocusRingClass(el) {
     if (classList(el).contains('focus-ring'))
       return;
-
     classList(el).add('focus-ring');
+    el.setAttribute('data-focus-ring-added', '');
     // Keep a reference to the element to which the focus-ring class is applied
     // so the focus-ring class can be restored to it if the window regains
     // focus after being blurred.
@@ -65,7 +65,10 @@ document.addEventListener('DOMContentLoaded', function() {
    * @param {Element} el
    */
   function removeFocusRingClass(el) {
+    if (!el.hasAttribute('data-focus-ring-added'))
+      return;
     classList(el).remove('focus-ring');
+    el.removeAttribute('data-focus-ring-added');
   }
 
   /**

--- a/src/focus-ring.js
+++ b/src/focus-ring.js
@@ -1,32 +1,24 @@
 import classList from 'dom-classlist';
-import matches from 'dom-matches';
 
 /* https://github.com/WICG/focus-ring */
 document.addEventListener('DOMContentLoaded', function() {
   var hadKeyboardEvent = false;
-  var keyboardThrottleTimeoutID = 0;
   var elWithFocusRing;
-
-  // These elements should always have a focus ring drawn, because they are
-  // associated with switching to a keyboard modality.
-  var keyboardModalityWhitelist = [
-    'input:not([type])',
-    'input[type=text]',
-    'input[type=search]',
-    'input[type=url]',
-    'input[type=tel]',
-    'input[type=email]',
-    'input[type=password]',
-    'input[type=number]',
-    'input[type=date]',
-    'input[type=month]',
-    'input[type=week]',
-    'input[type=time]',
-    'input[type=datetime]',
-    'input[type=datetime-local]',
-    'textarea',
-    '[role=textbox]',
-  ].join(',');
+  var inputTypesWhitelist = {
+    'text': true,
+    'search': true,
+    'url': true,
+    'tel': true,
+    'email': true,
+    'password': true,
+    'number': true,
+    'date': true,
+    'month': true,
+    'week': true,
+    'time': true,
+    'datetime': true,
+    'datetime-local': true,
+  };
 
   /**
    * Computes whether the given element should automatically trigger the
@@ -36,7 +28,22 @@ document.addEventListener('DOMContentLoaded', function() {
    * @return {boolean}
    */
   function focusTriggersKeyboardModality(el) {
-    return matches(el, keyboardModalityWhitelist) && matches(el, ':not([readonly])');
+    var type = el.type;
+    var tagName = el.tagName.toLowerCase();
+
+    if (tagName == 'input' && inputTypesWhitelist[type] && !el.readonly) {
+      return true;
+    }
+
+    if (tagName == 'textarea' && !el.readonly) {
+      return true;
+    }
+
+    if (el.getAttribute('role').toLowerCase() == 'textbox') {
+      return true;
+    }
+
+    return false;
   }
 
   /**
@@ -48,7 +55,6 @@ document.addEventListener('DOMContentLoaded', function() {
     if (classList(el).contains('focus-ring'))
       return;
     classList(el).add('focus-ring');
-    el.setAttribute('data-focus-ring-added', '');
     // Keep a reference to the element to which the focus-ring class is applied
     // so the focus-ring class can be restored to it if the window regains
     // focus after being blurred.
@@ -61,10 +67,7 @@ document.addEventListener('DOMContentLoaded', function() {
    * @param {Element} el
    */
   function removeFocusRingClass(el) {
-    if (!el.hasAttribute('data-focus-ring-added'))
-      return;
     classList(el).remove('focus-ring');
-    el.removeAttribute('data-focus-ring-added');
   }
 
   /**
@@ -72,31 +75,41 @@ document.addEventListener('DOMContentLoaded', function() {
    * are no further keyboard events.  The 100ms throttle handles cases where
    * focus is redirected programmatically after a keyboard event, such as
    * opening a menu or dialog.
+   * @param {Event} e
    */
-  function onKeyDown() {
-    hadKeyboardEvent = true;
+  function onKeyDown(e) {
+    if (e.altKey || e.ctrlKey || e.metaKey)
+      return;
+
+    var isTabKey = e.keyCode == 9;
+    var isTabNavigation = isTabKey || isTabKey && e.shiftKey;
+
+    if (!isTabNavigation)
+      return;
+
     // `activeElement` defaults to document.body if nothing focused,
     // so check the active element is actually focused.
-    if (matches(document.activeElement, ':focus'))
-      addFocusRingClass(document.activeElement);
-    if (keyboardThrottleTimeoutID !== 0)
-      clearTimeout(keyboardThrottleTimeoutID);
-    keyboardThrottleTimeoutID = setTimeout(function() {
-      hadKeyboardEvent = false;
-      keyboardThrottleTimeoutID = 0;
-    }, 100);
+    var activeElement = document.activeElement;
+    if (activeElement.tagName == 'body') {
+      return;
+    }
+
+    addFocusRingClass(activeElement);
+    hadKeyboardEvent = true;
   }
 
   /**
    * On `focus`, add the `focus-ring` class to the target if:
-   * - a keyboard event happened in the past 100ms, or
-   * - the focus event target triggers "keyboard modality" and should always
-   *   have a focus ring drawn.
+   * - a keydown event preceded the focus event, meaning the target received
+   *   focus as a result of keyboard navigation.
+   * - the event target is an element that will likely require interaction
+   *   via the keyboard (e.g. a text box)
    * @param {Event} e
    */
   function onFocus(e) {
     if (hadKeyboardEvent || focusTriggersKeyboardModality(e.target))
       addFocusRingClass(e.target);
+      hadKeyboardEvent = false;
   }
 
   /**
@@ -117,8 +130,8 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   }
 
-  document.body.addEventListener('keydown', onKeyDown, true);
-  document.body.addEventListener('focus', onFocus, true);
-  document.body.addEventListener('blur', onBlur, true);
+  document.addEventListener('keydown', onKeyDown, true);
+  document.addEventListener('focus', onFocus, true);
+  document.addEventListener('blur', onBlur, true);
   window.addEventListener('focus', onWindowFocus, true);
 });

--- a/src/focus-ring.js
+++ b/src/focus-ring.js
@@ -91,6 +91,9 @@ document.addEventListener('DOMContentLoaded', function() {
    * @param {Event} e
    */
   function onFocus(e) {
+    if (e.target == document)
+      return;
+
     if (hadKeyboardEvent || focusTriggersKeyboardModality(e.target)) {
       addFocusRingClass(e.target);
       hadKeyboardEvent = false;
@@ -102,6 +105,9 @@ document.addEventListener('DOMContentLoaded', function() {
    * @param {Event} e
    */
   function onBlur(e) {
+    if (e.target == document)
+      return;
+
     removeFocusRingClass(e.target);
   }
 

--- a/src/focus-ring.js
+++ b/src/focus-ring.js
@@ -29,12 +29,12 @@ document.addEventListener('DOMContentLoaded', function() {
    */
   function focusTriggersKeyboardModality(el) {
     var type = el.type;
-    var tagName = el.tagName.toLowerCase();
+    var tagName = el.tagName;
 
-    if (tagName == 'input' && inputTypesWhitelist[type] && !el.readonly)
+    if (tagName == 'INPUT' && inputTypesWhitelist[type] && !el.readonly)
       return true;
 
-    if (tagName == 'textarea' && !el.readonly)
+    if (tagName == 'TEXTAREA' && !el.readonly)
       return true;
 
     if (el.getAttribute('role').toLowerCase() == 'textbox')
@@ -72,10 +72,8 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   /**
-   * On `keydown`, set `hadKeyboardEvent`, to be removed 100ms later if there
-   * are no further keyboard events.  The 100ms throttle handles cases where
-   * focus is redirected programmatically after a keyboard event, such as
-   * opening a menu or dialog.
+   * On `keydown`, set `hadKeyboardEvent`, add `focus-ring` class if the
+   * key was Tab.
    * @param {Event} e
    */
   function onKeyDown(e) {
@@ -88,7 +86,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // `activeElement` defaults to document.body if nothing focused,
     // so check the active element is actually focused.
     var activeElement = document.activeElement;
-    if (activeElement.tagName == 'body')
+    if (activeElement.tagName == 'BODY')
       return;
 
     addFocusRingClass(activeElement);


### PR DESCRIPTION
This PR addresses [issue #33](https://github.com/WICG/focus-ring/issues/33) by refining the heuristics for when the focus-ring class is applied: if the user navigates to it via `Tab` or `Shift` + `Tab`.

In addition, this PR also:

1. Removes use of `data-focus-ring-added` attribute
2. Removes the need for use of `dom-matches` polyfill dependency 
3. Removes the need for `setTimeout()` when handling the `keydown` event.