### PR TITLE
Ensure focus-ring class is applied to contenteditable elements

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -8,7 +8,7 @@
       font-family: arial, sans-serif;
       }
       div { margin: 1em 0; }
-      div[role="textbox"] {
+      div[contenteditable] {
       width: 10em;
       min-height: 2em;
       padding: 0.2em;
@@ -45,7 +45,13 @@
       <textarea placeholder="Multi line"></textarea>
     </div>
     <div>
-      <div id="s" role="textbox" tabindex="0" contenteditable="true">Contenteditable with textbox role</div>
+      <div contenteditable="true">Contenteditable explicitly set to true</div>
+    </div>
+    <div>
+      <div contenteditable>Contenteditable</div>
+    </div>
+    <div>
+      <div role="textbox" contenteditable="true">Contenteditable with textbox role</div>
     </div>
     <h2>Buttons</h2>
     <div>

--- a/dist/focus-ring.js
+++ b/dist/focus-ring.js
@@ -201,15 +201,15 @@ document.addEventListener('DOMContentLoaded', function() {
    */
   function focusTriggersKeyboardModality(el) {
     var type = el.type;
-    var tagName = el.tagName.toLowerCase();
+    var tagName = el.tagName;
 
-    if (tagName == 'input' && inputTypesWhitelist[type] && !el.readonly)
+    if (tagName == 'INPUT' && inputTypesWhitelist[type] && !el.readonly)
       return true;
 
-    if (tagName == 'textarea' && !el.readonly)
+    if (tagName == 'TEXTAREA' && !el.readonly)
       return true;
 
-    if (el.contentEditable)
+    if (el.contentEditable == 'true')
       return true;
 
     return false;
@@ -250,13 +250,14 @@ document.addEventListener('DOMContentLoaded', function() {
    * opening a menu or dialog.
    */
   function onKeyDown() {
+    hadKeyboardEvent = true;
+
     // `activeElement` defaults to document.body if nothing focused,
     // so check the active element is actually focused.
     var activeElement = document.activeElement;
-    if (activeElement.tagName.toLowerCase() == 'body')
+    if (activeElement.tagName == 'BODY')
       return;
 
-    hadKeyboardEvent = true;
     if (keyboardThrottleTimeoutID !== 0)
       clearTimeout(keyboardThrottleTimeoutID);
     keyboardThrottleTimeoutID = setTimeout(function() {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "rollup-watch": "^3.2.2"
   },
   "dependencies": {
-    "dom-classlist": "^1.0.1",
-    "dom-matches": "^2.0.0"
+    "dom-classlist": "^1.0.1"
   }
 }

--- a/src/focus-ring.js
+++ b/src/focus-ring.js
@@ -33,13 +33,13 @@ document.addEventListener('DOMContentLoaded', function() {
     var type = el.type;
     var tagName = el.tagName;
 
-    if (tagName == 'input' && inputTypesWhitelist[type] && !el.readonly)
+    if (tagName == 'INPUT' && inputTypesWhitelist[type] && !el.readonly)
       return true;
 
-    if (tagName == 'textarea' && !el.readonly)
+    if (tagName == 'TEXTAREA' && !el.readonly)
       return true;
 
-    if (el.contentEditable)
+    if (el.contentEditable == 'true')
       return true;
 
     return false;
@@ -83,7 +83,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // `activeElement` defaults to document.body if nothing focused,
     // so check the active element is actually focused.
     var activeElement = document.activeElement;
-    if (activeElement.tagName == 'body')
+    if (activeElement.tagName == 'BODY')
       return;
 
     hadKeyboardEvent = true;

--- a/src/focus-ring.js
+++ b/src/focus-ring.js
@@ -31,7 +31,7 @@ document.addEventListener('DOMContentLoaded', function() {
    */
   function focusTriggersKeyboardModality(el) {
     var type = el.type;
-    var tagName = el.tagName.toLowerCase();
+    var tagName = el.tagName;
 
     if (tagName == 'input' && inputTypesWhitelist[type] && !el.readonly)
       return true;
@@ -83,7 +83,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // `activeElement` defaults to document.body if nothing focused,
     // so check the active element is actually focused.
     var activeElement = document.activeElement;
-    if (activeElement.tagName.toLowerCase() == 'body')
+    if (activeElement.tagName == 'body')
       return;
 
     hadKeyboardEvent = true;

--- a/src/focus-ring.js
+++ b/src/focus-ring.js
@@ -1,5 +1,4 @@
 import classList from 'dom-classlist';
-import matches from 'dom-matches';
 
 /* https://github.com/WICG/focus-ring */
 document.addEventListener('DOMContentLoaded', function() {
@@ -7,26 +6,21 @@ document.addEventListener('DOMContentLoaded', function() {
   var keyboardThrottleTimeoutID = 0;
   var elWithFocusRing;
 
-  // These elements should always have a focus ring drawn, because they are
-  // associated with switching to a keyboard modality.
-  var keyboardModalityWhitelist = [
-    'input:not([type])',
-    'input[type=text]',
-    'input[type=search]',
-    'input[type=url]',
-    'input[type=tel]',
-    'input[type=email]',
-    'input[type=password]',
-    'input[type=number]',
-    'input[type=date]',
-    'input[type=month]',
-    'input[type=week]',
-    'input[type=time]',
-    'input[type=datetime]',
-    'input[type=datetime-local]',
-    'textarea',
-    '[role=textbox]',
-  ].join(',');
+  var inputTypesWhitelist = {
+    'text': true,
+    'search': true,
+    'url': true,
+    'tel': true,
+    'email': true,
+    'password': true,
+    'number': true,
+    'date': true,
+    'month': true,
+    'week': true,
+    'time': true,
+    'datetime': true,
+    'datetime-local': true,
+  };
 
   /**
    * Computes whether the given element should automatically trigger the
@@ -36,7 +30,19 @@ document.addEventListener('DOMContentLoaded', function() {
    * @return {boolean}
    */
   function focusTriggersKeyboardModality(el) {
-    return matches(el, keyboardModalityWhitelist) && matches(el, ':not([readonly])');
+    var type = el.type;
+    var tagName = el.tagName.toLowerCase();
+
+    if (tagName == 'input' && inputTypesWhitelist[type] && !el.readonly)
+      return true;
+
+    if (tagName == 'textarea' && !el.readonly)
+      return true;
+
+    if (el.contentEditable)
+      return true;
+
+    return false;
   }
 
   /**
@@ -74,11 +80,13 @@ document.addEventListener('DOMContentLoaded', function() {
    * opening a menu or dialog.
    */
   function onKeyDown() {
-    hadKeyboardEvent = true;
     // `activeElement` defaults to document.body if nothing focused,
     // so check the active element is actually focused.
-    if (matches(document.activeElement, ':focus'))
-      addFocusRingClass(document.activeElement);
+    var activeElement = document.activeElement;
+    if (activeElement.tagName.toLowerCase() == 'body')
+      return;
+
+    hadKeyboardEvent = true;
     if (keyboardThrottleTimeoutID !== 0)
       clearTimeout(keyboardThrottleTimeoutID);
     keyboardThrottleTimeoutID = setTimeout(function() {

--- a/src/focus-ring.js
+++ b/src/focus-ring.js
@@ -80,13 +80,14 @@ document.addEventListener('DOMContentLoaded', function() {
    * opening a menu or dialog.
    */
   function onKeyDown() {
+    hadKeyboardEvent = true;
+
     // `activeElement` defaults to document.body if nothing focused,
     // so check the active element is actually focused.
     var activeElement = document.activeElement;
     if (activeElement.tagName == 'BODY')
       return;
 
-    hadKeyboardEvent = true;
     if (keyboardThrottleTimeoutID !== 0)
       clearTimeout(keyboardThrottleTimeoutID);
     keyboardThrottleTimeoutID = setTimeout(function() {


### PR DESCRIPTION
This PR addresses issue #7 and ensures the `focus-ring` class is applied to contenteditable elements. Additionally, it removes the dom-matches polyfill dependency and updates the demo with more use cases.