### PR TITLE
Style keyboard focus on keyup

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -37,6 +37,20 @@
       You should see the normal platform focus indicator on elements below differently based on whether you interact with them via keyboard or mouse.
       If you are using the mouse and get lost, at any time you can press a key (such as Shift) to have the focus indicator appear.
     </p>
+    <h2>Buttons</h2>
+    <div>
+      <label><input type="checkbox">Checkbox</label>
+    </div>
+    <div>
+      <label><input name="a" type="radio">Radio 1</label>
+      <label><input name="a" type="radio">Radio 2</label>
+    </div>
+    <div>
+      <button>Button</button>
+    </div>
+    <div>
+      <input type="submit" value="Submit button">
+    </div>
     <h2>Editable text</h2>
     <div>
       <input placeholder="Single line">
@@ -52,20 +66,6 @@
     </div>
     <div>
       <div role="textbox" contenteditable="true">Contenteditable with textbox role</div>
-    </div>
-    <h2>Buttons</h2>
-    <div>
-      <button>Button</button>
-    </div>
-    <div>
-      <input type="submit" value="Submit button">
-    </div>
-    <div>
-      <label><input type="checkbox">Checkbox</label>
-    </div>
-    <div>
-      <label><input name="a" type="radio">Radio 1</label>
-      <label><input name="a" type="radio">Radio 2</label>
     </div>
     <h2>Focusable <code>&lt;div&gt;</code>s</h2>
       <div tabindex="0"><code>tabindex="0"</code></div>

--- a/dist/focus-ring.js
+++ b/dist/focus-ring.js
@@ -174,10 +174,14 @@ ClassList.prototype.toggle = function (token, force) {
  * https://github.com/WICG/focus-ring
  */
 function init() {
-  var hadKeyboardEvent = false;
   var elWithFocusRing;
 
   var inputTypesWhitelist = {
+    'radio': true,
+    'checkbox': true,
+    'button': true,
+    'reset': true,
+    'submit': true,
     'text': true,
     'search': true,
     'url': true,
@@ -241,34 +245,27 @@ function init() {
   }
 
   /**
-   * On `keydown`, set `hadKeyboardEvent`, add `focus-ring` class if the
-   * key was Tab.
+   * On `keyup` add `focus-ring` class if the user pressed Tab and the event
+   * target is an element that will likely require interaction via the
+   * keyboard (e.g. a text box).
+   * The `keyup` event is used over the focus event because:
+   * 1. `focus` is a device-independent event, and `keyup` ensures the
+   *    `focus-ring` class is only added when focus originates from
+   *    keyboard navigation.
+   * 2. Unlike `focus`, keyup` will fire when the user navigates from the
+   *    browser chrome into the document. (For more, see issue #15)
    * @param {Event} e
    */
-  function onKeyDown(e) {
+  function onKeyUp(e) {
     if (e.altKey || e.ctrlKey || e.metaKey)
       return;
 
     if (e.keyCode != 9)
       return;
 
-    hadKeyboardEvent = true;
-  }
-
-  /**
-   * On `focus`, add the `focus-ring` class to the target if:
-   * - the target received focus as a result of keyboard navigation
-   * - the event target is an element that will likely require interaction
-   *   via the keyboard (e.g. a text box)
-   * @param {Event} e
-   */
-  function onFocus(e) {
-    if (e.target == document)
-      return;
-
-    if (hadKeyboardEvent || focusTriggersKeyboardModality(e.target)) {
-      addFocusRingClass(e.target);
-      hadKeyboardEvent = false;
+    var target = e.target;
+    if (focusTriggersKeyboardModality(target)) {
+      addFocusRingClass(target);
     }
   }
 
@@ -315,8 +312,7 @@ function init() {
     }
   }
 
-  document.addEventListener('keydown', onKeyDown, true);
-  document.addEventListener('focus', onFocus, true);
+  document.addEventListener('keyup', onKeyUp, true);
   document.addEventListener('blur', onBlur, true);
   window.addEventListener('focus', onWindowFocus, true);
   window.addEventListener('blur', onWindowBlur, true);


### PR DESCRIPTION
This PR fixes issues #15 **and** #54. The core idea is to changeup _how_ we style focus, moving from adding the `focus-ring` class in response to `focus` events preceded by `keydown` events, to simply leveraging `keydown` instead.

As noted in the code comments: `keyup` provides two advantages over our current approach:
- It will reliably fire when the user is navigating from the browser chrome into the document (fixing issue #33).
- Requires one less event listener, while still ensuring we add `focus-ring` only in response to `focus` originating from the keyboard.