### PR TITLE
Revert behavior to fix failing tests. Add arrow key support. Fixes #65, #54, #63, #44

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
+os: osx
+addons:
+  chrome: stable
+  firefox: "57.0"
 language: node_js
 node_js:
-  - "7"
-
-install:
-  - npm install
+  - "8"

--- a/dist/focus-ring.js
+++ b/dist/focus-ring.js
@@ -76,14 +76,18 @@ function init() {
 
   /**
    * On `keydown`, set `hadKeyboardEvent`, add `focus-ring` class if the
-   * key was Tab.
+   * key was Tab/Shift-Tab or Arrow Keys.
    * @param {Event} e
    */
   function onKeyDown(e) {
+    const allowedKeys = [9, 37, 38, 39, 40];
+
+    // If the user is holding down a modifier key, abort.
     if (e.altKey || e.ctrlKey || e.metaKey)
       return;
 
-    if (e.keyCode != 9)
+    // If the key can't be found in the list of allowed keys, abort.
+    if (allowedKeys.indexOf(e.keyCode) === -1)
       return;
 
     hadKeyboardEvent = true;

--- a/dist/focus-ring.js
+++ b/dist/focus-ring.js
@@ -5,183 +5,13 @@
 }(this, (function () { 'use strict';
 
 /**
- * Module export
- *
- * @param {Element} el
- * @return {ClassList}
- */
-
-var domClasslist = function (el) {
-  return new ClassList(el);
-};
-
-/**
- * Initialize a new ClassList for the given element
- *
- * @param {Element} el DOM Element
- */
-function ClassList(el) {
-  if (!el || el.nodeType !== 1) {
-    throw new Error('A DOM Element reference is required');
-  }
-
-  this.el = el;
-  this.classList = el.classList;
-}
-
-/**
- * Check token validity
- *
- * @param token
- * @param [method]
- */
-function checkToken(token, method) {
-  method = method || 'a method';
-
-  if (typeof token != 'string') {
-    throw new TypeError(
-      'Failed to execute \'' + method + '\' on \'ClassList\': ' +
-      'the token provided (\'' + token + '\') is not a string.'
-    );
-  }
-  if (token === "") {
-    throw new SyntaxError(
-      'Failed to execute \'' + method + '\' on \'ClassList\': ' +
-      'the token provided must not be empty.'
-    );
-  }
-  if (/\s/.test(token)) {
-    throw new Error(
-      'Failed to execute \'' + method + '\' on \'ClassList\': ' +
-      'the token provided (\'' + token + '\') contains HTML space ' +
-      'characters, which are not valid in tokens.'
-    );
-  }
-}
-
-/**
- * Return an array of the class names on the element.
- *
- * @return {Array}
- */
-ClassList.prototype.toArray = function () {
-  var str = (this.el.getAttribute('class') || '').replace(/^\s+|\s+$/g, '');
-  var classes = str.split(/\s+/);
-  if ('' === classes[0]) { classes.shift(); }
-  return classes;
-};
-
-/**
- * Add the given `token` to the class list if it's not already present.
- *
- * @param {String} token
- */
-ClassList.prototype.add = function (token) {
-  var classes, index, updated;
-  checkToken(token, 'add');
-
-  if (this.classList) {
-    this.classList.add(token);
-  }
-  else {
-    // fallback
-    classes = this.toArray();
-    index = classes.indexOf(token);
-    if (index === -1) {
-      classes.push(token);
-      this.el.setAttribute('class', classes.join(' '));
-    }
-  }
-
-  return;
-};
-
-/**
- * Check if the given `token` is in the class list.
- *
- * @param {String} token
- * @return {Boolean}
- */
-ClassList.prototype.contains = function (token) {
-  checkToken(token, 'contains');
-
-  return this.classList ?
-    this.classList.contains(token) :
-    this.toArray().indexOf(token) > -1;
-};
-
-/**
- * Remove any class names that match the given `token`, when present.
- *
- * @param {String|RegExp} token
- */
-ClassList.prototype.remove = function (token) {
-  var arr, classes, i, index, len;
-
-  if ('[object RegExp]' == Object.prototype.toString.call(token)) {
-    arr = this.toArray();
-    for (i = 0, len = arr.length; i < len; i++) {
-      if (token.test(arr[i])) {
-        this.remove(arr[i]);
-      }
-    }
-  }
-  else {
-    checkToken(token, 'remove');
-
-    if (this.classList) {
-      this.classList.remove(token);
-    }
-    else {
-      // fallback
-      classes = this.toArray();
-      index = classes.indexOf(token);
-      if (index > -1) {
-        classes.splice(index, 1);
-        this.el.setAttribute('class', classes.join(' '));
-      }
-    }
-  }
-
-  return;
-};
-
-/**
- * Toggle the `token` in the class list. Optionally force state via `force`.
- *
- * Native `classList` is not used as some browsers that support `classList` do
- * not support `force`. Avoiding `classList` altogether keeps this function
- * simple.
- *
- * @param {String} token
- * @param {Boolean} [force]
- * @return {Boolean}
- */
-ClassList.prototype.toggle = function (token, force) {
-  checkToken(token, 'toggle');
-
-  var hasToken = this.contains(token);
-  var method = hasToken ? (force !== true && 'remove') : (force !== false && 'add');
-
-  if (method) {
-    this[method](token);
-  }
-
-  return (typeof force == 'boolean' ? force : !hasToken);
-};
-
-/**
  * https://github.com/WICG/focus-ring
  */
 function init() {
+  var hadKeyboardEvent = true;
   var elWithFocusRing;
 
   var inputTypesWhitelist = {
-    'radio': true,
-    'checkbox': true,
-    'button': true,
-    'reset': true,
-    'submit': true,
     'text': true,
     'search': true,
     'url': true,
@@ -226,9 +56,9 @@ function init() {
    * @param {Element} el
    */
   function addFocusRingClass(el) {
-    if (domClasslist(el).contains('focus-ring'))
+    if (el.classList.contains('focus-ring'))
       return;
-    domClasslist(el).add('focus-ring');
+    el.classList.add('focus-ring');
     el.setAttribute('data-focus-ring-added', '');
   }
 
@@ -240,32 +70,39 @@ function init() {
   function removeFocusRingClass(el) {
     if (!el.hasAttribute('data-focus-ring-added'))
       return;
-    domClasslist(el).remove('focus-ring');
+    el.classList.remove('focus-ring');
     el.removeAttribute('data-focus-ring-added');
   }
 
   /**
-   * On `keyup` add `focus-ring` class if the user pressed Tab and the event
-   * target is an element that will likely require interaction via the
-   * keyboard (e.g. a text box).
-   * The `keyup` event is used over the focus event because:
-   * 1. `focus` is a device-independent event, and `keyup` ensures the
-   *    `focus-ring` class is only added when focus originates from
-   *    keyboard navigation.
-   * 2. Unlike `focus`, keyup` will fire when the user navigates from the
-   *    browser chrome into the document. (For more, see issue #15)
+   * On `keydown`, set `hadKeyboardEvent`, add `focus-ring` class if the
+   * key was Tab.
    * @param {Event} e
    */
-  function onKeyUp(e) {
+  function onKeyDown(e) {
     if (e.altKey || e.ctrlKey || e.metaKey)
       return;
 
     if (e.keyCode != 9)
       return;
 
-    var target = e.target;
-    if (focusTriggersKeyboardModality(target)) {
-      addFocusRingClass(target);
+    hadKeyboardEvent = true;
+  }
+
+  /**
+   * On `focus`, add the `focus-ring` class to the target if:
+   * - the target received focus as a result of keyboard navigation
+   * - the event target is an element that will likely require interaction
+   *   via the keyboard (e.g. a text box)
+   * @param {Event} e
+   */
+  function onFocus(e) {
+    if (e.target == document)
+      return;
+
+    if (hadKeyboardEvent || focusTriggersKeyboardModality(e.target)) {
+      addFocusRingClass(e.target);
+      hadKeyboardEvent = false;
     }
   }
 
@@ -285,10 +122,7 @@ function init() {
    * to which it was previously applied.
    */
   function onWindowFocus() {
-    // When removing the activeElement from DOM it's possible IE11 is in state
-    // document.activeElement === null
-    if (!document.activeElement)
-      return;
+    window.removeEventListener('focus', onWindowFocus, true);
     if (document.activeElement == elWithFocusRing)
       addFocusRingClass(elWithFocusRing);
 
@@ -298,13 +132,15 @@ function init() {
   /**
    * When switching windows, keep track of the focused element if it has a
    * focus-ring class.
+   * @param {Event} e
    */
-  function onWindowBlur() {
-    // When removing the activeElement from DOM it's possible IE11 is in state
-    // document.activeElement === null
-    if (!document.activeElement)
+  function onWindowBlur(e) {
+    if (e.target !== window)
       return;
-    if (domClasslist(document.activeElement).contains('focus-ring')) {
+
+    window.addEventListener('focus', onWindowFocus, true);
+    addInitialPointerMoveListeners();
+    if (document.activeElement.classList.contains('focus-ring')) {
       // Keep a reference to the element to which the focus-ring class is applied
       // so the focus-ring class can be restored to it if the window regains
       // focus after being blurred.
@@ -312,12 +148,59 @@ function init() {
     }
   }
 
-  document.addEventListener('keyup', onKeyUp, true);
+  /**
+   * Add a group of listeners to detect a fine-grained pointing device.
+   * These listeners will be added when the polyfill first loads, and if
+   * the window is blurred and regains focus.
+   */
+  function addInitialPointerMoveListeners() {
+    document.addEventListener('mousemove', onInitialPointerMove);
+    document.addEventListener('mousedown', onInitialPointerMove);
+    document.addEventListener('mouseup', onInitialPointerMove);
+    document.addEventListener('pointermove', onInitialPointerMove);
+    document.addEventListener('pointerdown', onInitialPointerMove);
+    document.addEventListener('pointerup', onInitialPointerMove);
+    document.addEventListener('touchmove', onInitialPointerMove);
+    document.addEventListener('touchstart', onInitialPointerMove);
+    document.addEventListener('touchend', onInitialPointerMove);
+  }
+
+  /**
+   * When the polfyill first loads, assume the user is in keyboard modality.
+   * If any event is received from a fine-grained pointing device (mouse, pointer, touch),
+   * turn off keyboard modality.
+   * This accounts for situations where focus enters the page from the URL bar.
+   * In that scenario, the keydown event is inconsistent, so we can't use it to detect modality.
+   * But the odds are pretty good we'll get one of the other pointing device events
+   * and any of them should act as a signal that this is not keyboard focus.
+   * @param {Event} e
+   */
+  function onInitialPointerMove(e) {
+    // Work around a Safari quirk that fires a mousemove on <html> whenever the window blurs,
+    // even if you're tabbing out of the page. ¯\_(ツ)_/¯
+    if (e.target.nodeName.toLowerCase() === 'html')
+      return;
+
+    hadKeyboardEvent = false;
+    document.removeEventListener('mousemove', onInitialPointerMove);
+    document.removeEventListener('mousedown', onInitialPointerMove);
+    document.removeEventListener('mouseup', onInitialPointerMove);
+    document.removeEventListener('pointermove', onInitialPointerMove);
+    document.removeEventListener('pointerdown', onInitialPointerMove);
+    document.removeEventListener('pointerup', onInitialPointerMove);
+    document.removeEventListener('touchmove', onInitialPointerMove);
+    document.removeEventListener('touchstart', onInitialPointerMove);
+    document.removeEventListener('touchend', onInitialPointerMove);
+  }
+
+  document.addEventListener('keydown', onKeyDown, true);
+  document.addEventListener('focus', onFocus, true);
   document.addEventListener('blur', onBlur, true);
   window.addEventListener('focus', onWindowFocus, true);
   window.addEventListener('blur', onWindowBlur, true);
+  addInitialPointerMoveListeners();
 
-  domClasslist(document.body).add('js-focus-ring');
+  document.body.classList.add('js-focus-ring');
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -240,21 +240,6 @@
         "repeat-element": "1.1.2"
       }
     },
-    "browser-resolve": {
-      "version": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
-      "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
-      "dev": true,
-      "requires": {
-        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
-      },
-      "dependencies": {
-        "resolve": {
-          "version": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
-        }
-      }
-    },
     "browser-stdout": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
@@ -270,11 +255,6 @@
     "buffer-shims": {
       "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
       "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-      "dev": true
-    },
-    "builtin-modules": {
-      "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
     "caller-callsite": {
@@ -728,7 +708,8 @@
       }
     },
     "dom-classlist": {
-      "version": "https://registry.npmjs.org/dom-classlist/-/dom-classlist-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dom-classlist/-/dom-classlist-1.0.1.tgz",
       "integrity": "sha1-cigU3C9QnT19BvJTO6n/SO7qWbk="
     },
     "duplexer2": {
@@ -939,7 +920,8 @@
       }
     },
     "eslint-config-google": {
-      "version": "https://registry.npmjs.org/eslint-config-google/-/eslint-config-google-0.7.1.tgz",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-google/-/eslint-config-google-0.7.1.tgz",
       "integrity": "sha1-VZj4SY6eB4Qg80uASVuNlZ9lH7I=",
       "dev": true
     },
@@ -1681,11 +1663,6 @@
       "requires": {
         "is-extglob": "1.0.0"
       }
-    },
-    "is-module": {
-      "version": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
-      "dev": true
     },
     "is-my-json-valid": {
       "version": "2.16.1",
@@ -2641,11 +2618,6 @@
         "uuid": "3.1.0"
       }
     },
-    "require-relative": {
-      "version": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
-      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
-      "dev": true
-    },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
@@ -2695,11 +2667,29 @@
       }
     },
     "rollup": {
-      "version": "https://registry.npmjs.org/rollup/-/rollup-0.41.6.tgz",
+      "version": "0.41.6",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.41.6.tgz",
       "integrity": "sha1-4NBUl4d6OYwQTYFtJzOnGKepTio=",
       "dev": true,
       "requires": {
-        "source-map-support": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz"
+        "source-map-support": "0.4.18"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.4.18",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.7"
+          }
+        }
       }
     },
     "rollup-plugin-commonjs": {
@@ -2733,14 +2723,61 @@
       }
     },
     "rollup-plugin-node-resolve": {
-      "version": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.0.tgz",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.0.tgz",
       "integrity": "sha1-i4l8TDAw1QASd7BRSyXSygloPuA=",
       "dev": true,
       "requires": {
-        "browser-resolve": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
-        "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-        "is-module": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz"
+        "browser-resolve": "1.11.2",
+        "builtin-modules": "1.1.1",
+        "is-module": "1.0.0",
+        "resolve": "1.5.0"
+      },
+      "dependencies": {
+        "browser-resolve": {
+          "version": "1.11.2",
+          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+          "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+          "dev": true,
+          "requires": {
+            "resolve": "1.1.7"
+          },
+          "dependencies": {
+            "resolve": {
+              "version": "1.1.7",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+              "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+              "dev": true
+            }
+          }
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+          "dev": true
+        },
+        "is-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+          "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+          "dev": true
+        },
+        "path-parse": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+          "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+          "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "1.0.5"
+          }
+        }
       }
     },
     "rollup-pluginutils": {
@@ -2762,11 +2799,20 @@
       }
     },
     "rollup-watch": {
-      "version": "https://registry.npmjs.org/rollup-watch/-/rollup-watch-3.2.2.tgz",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/rollup-watch/-/rollup-watch-3.2.2.tgz",
       "integrity": "sha1-XldCMunvNtqRd/RpRtgIDLJnNUs=",
       "dev": true,
       "requires": {
-        "require-relative": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz"
+        "require-relative": "0.8.7"
+      },
+      "dependencies": {
+        "require-relative": {
+          "version": "0.8.7",
+          "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
+          "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
+          "dev": true
+        }
       }
     },
     "run-async": {
@@ -2982,19 +3028,6 @@
       "dev": true,
       "requires": {
         "hoek": "4.2.0"
-      }
-    },
-    "source-map": {
-      "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
-      "dev": true
-    },
-    "source-map-support": {
-      "version": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
-      "integrity": "sha1-nURjdyWYuGJxtPUj9sH04Cp9au8=",
-      "dev": true,
-      "requires": {
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
       }
     },
     "spawn-command": {

--- a/src/focus-ring.js
+++ b/src/focus-ring.js
@@ -71,14 +71,18 @@ function init() {
 
   /**
    * On `keydown`, set `hadKeyboardEvent`, add `focus-ring` class if the
-   * key was Tab.
+   * key was Tab/Shift-Tab or Arrow Keys.
    * @param {Event} e
    */
   function onKeyDown(e) {
+    const allowedKeys = [9, 37, 38, 39, 40];
+
+    // If the user is holding down a modifier key, abort.
     if (e.altKey || e.ctrlKey || e.metaKey)
       return;
 
-    if (e.keyCode != 9)
+    // If the key can't be found in the list of allowed keys, abort.
+    if (allowedKeys.indexOf(e.keyCode) === -1)
       return;
 
     hadKeyboardEvent = true;

--- a/test/fixtures/contenteditable-textbox.html
+++ b/test/fixtures/contenteditable-textbox.html
@@ -20,6 +20,12 @@
     </style>
   </head>
   <body>
+    <!--
+      FF won't focus a div with contenteditable if it's the first element on the page.
+      https://jsbin.com/cawevo/edit?html,output
+      Add a dummy button so Selenium can use it as the first focus target.
+    -->
+    <button id="start">Dummy</button>
     <div role="textbox" contenteditable="true" id="el"></div>
     <script src="/dist/focus-ring.js"></script>
   </body>

--- a/test/fixtures/contenteditable-true.html
+++ b/test/fixtures/contenteditable-true.html
@@ -20,6 +20,12 @@
     </style>
   </head>
   <body>
+    <!--
+      FF won't focus a div with contenteditable if it's the first element on the page.
+      https://jsbin.com/cawevo/edit?html,output
+      Add a dummy button so Selenium can use it as the first focus target.
+    -->
+    <button id="start">Dummy</button>
     <div contenteditable="true" id="el"></div>
     <script src="/dist/focus-ring.js"></script>
   </body>

--- a/test/fixtures/contenteditable.html
+++ b/test/fixtures/contenteditable.html
@@ -20,6 +20,12 @@
     </style>
   </head>
   <body>
+    <!--
+      FF won't focus a div with contenteditable if it's the first element on the page.
+      https://jsbin.com/cawevo/edit?html,output
+      Add a dummy button so Selenium can use it as the first focus target.
+    -->
+    <button id="start">Dummy</button>
     <div contenteditable id="el"></div>
     <script src="/dist/focus-ring.js"></script>
   </body>

--- a/test/fixtures/input-radio-group.html
+++ b/test/fixtures/input-radio-group.html
@@ -15,7 +15,7 @@
   </head>
   <body>
     <input type="radio" name="foo" id="first">
-    <input type="radio" name="foo" id="el">
+    <input type="radio" name="foo" id="last">
     <script src="/dist/focus-ring.js"></script>
   </body>
 </html>

--- a/test/index.js
+++ b/test/index.js
@@ -85,7 +85,7 @@ function runMocha(driver, mocha) {
  */
 function browserFilter(browser) {
   return browser.getReleaseName() === 'stable'
-    && ['firefox', 'chrome'].includes(browser.getId());
+    && ['chrome', 'firefox'].includes(browser.getId());
 }
 
 /**

--- a/test/specs/button.js
+++ b/test/specs/button.js
@@ -1,6 +1,6 @@
 const {fixture, matchesKeyboard, matchesMouse} = require('./helpers');
 
-describe.only('<button>', function() {
+describe('<button>', function() {
   beforeEach(function() {
     return fixture('button.html');
   });

--- a/test/specs/contenteditable-textbox.js
+++ b/test/specs/contenteditable-textbox.js
@@ -1,18 +1,26 @@
-const {fixture, matchesKeyboard, matchesMouse} = require('./helpers');
+const {fixture, matchesKeyboard, matchesMouse, FOCUS_RING_STYLE} = require('./helpers');
+const {Key, By} = require('selenium-webdriver');
+const expect = require('expect');
+const driver = global.__driver;
 
 describe('<div role="textbox" contenteditable="true">', function() {
   beforeEach(function() {
-    return fixture('contenteditable-true.html');
+    return fixture('contenteditable-textbox.html');
   });
 
-  // This test seems to fail because FF won't focus a div with contenteditable
-  // if it's the first element on the page. Weird.
-  // https://jsbin.com/cawevo/edit?html,output
-  it.skip('should apply .focus-ring on keyboard focus', function() {
-    return matchesKeyboard();
+  // FF won't focus a div with contenteditable if it's the first element on the page.
+  // So we click on a dummy element to move focus into the document.
+  it('should apply .focus-ring on keyboard focus', async function() {
+    let start = await driver.findElement(By.css('#start'));
+    await start.click();
+    await start.sendKeys(Key.TAB);
+    let actual = await driver.executeScript(`
+      return window.getComputedStyle(document.querySelector('#el')).outlineColor
+    `);
+    expect(actual).toEqual(FOCUS_RING_STYLE);
   });
 
-  it.skip('should apply .focus-ring on mouse focus', function() {
+  it('should apply .focus-ring on mouse focus', async function() {
     return matchesMouse();
   });
 });

--- a/test/specs/contenteditable-true.js
+++ b/test/specs/contenteditable-true.js
@@ -1,18 +1,26 @@
-const {fixture, matchesKeyboard, matchesMouse} = require('./helpers');
+const {fixture, matchesKeyboard, matchesMouse, FOCUS_RING_STYLE} = require('./helpers');
+const {Key, By} = require('selenium-webdriver');
+const expect = require('expect');
+const driver = global.__driver;
 
 describe('<div contenteditable="true">', function() {
   beforeEach(function() {
     return fixture('contenteditable-true.html');
   });
 
-  // This test seems to fail because FF won't focus a div with contenteditable
-  // if it's the first element on the page. Weird.
-  // https://jsbin.com/cawevo/edit?html,output
-  it.skip('should apply .focus-ring on keyboard focus', function() {
-    return matchesKeyboard();
+  // FF won't focus a div with contenteditable if it's the first element on the page.
+  // So we click on a dummy element to move focus into the document.
+  it('should apply .focus-ring on keyboard focus', async function() {
+    let start = await driver.findElement(By.css('#start'));
+    await start.click();
+    await start.sendKeys(Key.TAB);
+    let actual = await driver.executeScript(`
+      return window.getComputedStyle(document.querySelector('#el')).outlineColor
+    `);
+    expect(actual).toEqual(FOCUS_RING_STYLE);
   });
 
-  it.skip('should apply .focus-ring on mouse focus', function() {
+  it('should apply .focus-ring on mouse focus', async function() {
     return matchesMouse();
   });
 });

--- a/test/specs/contenteditable.js
+++ b/test/specs/contenteditable.js
@@ -1,18 +1,26 @@
-const {fixture, matchesKeyboard, matchesMouse} = require('./helpers');
+const {fixture, matchesKeyboard, matchesMouse, FOCUS_RING_STYLE} = require('./helpers');
+const {Key, By} = require('selenium-webdriver');
+const expect = require('expect');
+const driver = global.__driver;
 
 describe('<div contenteditable>', function() {
   beforeEach(function() {
     return fixture('contenteditable.html');
   });
 
-  // This test seems to fail because FF won't focus a div with contenteditable
-  // if it's the first element on the page. Weird.
-  // https://jsbin.com/cawevo/edit?html,output
-  it.skip('should apply .focus-ring on keyboard focus', function() {
-    return matchesKeyboard();
+  // FF won't focus a div with contenteditable if it's the first element on the page.
+  // So we click on a dummy element to move focus into the document.
+  it('should apply .focus-ring on keyboard focus', async function() {
+    let start = await driver.findElement(By.css('#start'));
+    await start.click();
+    await start.sendKeys(Key.TAB);
+    let actual = await driver.executeScript(`
+      return window.getComputedStyle(document.querySelector('#el')).outlineColor
+    `);
+    expect(actual).toEqual(FOCUS_RING_STYLE);
   });
 
-  it.skip('should apply .focus-ring on mouse focus', function() {
+  it('should apply .focus-ring on mouse focus', async function() {
     return matchesMouse();
   });
 });

--- a/test/specs/input-file.js
+++ b/test/specs/input-file.js
@@ -10,6 +10,8 @@ describe('<input type="file">', function() {
     return matchesKeyboard();
   });
 
+  // Note: Skipping this test (though it currently passes) because it opens
+  // a file chooser dialog and I don't want it interfering with other tests.
   it.skip('should NOT apply .focus-ring on mouse focus', function() {
     return matchesMouse(false);
   });

--- a/test/specs/input-radio-group.js
+++ b/test/specs/input-radio-group.js
@@ -9,25 +9,25 @@ describe('<input type="radio"> group', function() {
   });
 
   it('should apply .focus-ring on keyboard focus', async function() {
-      let body = await driver.findElement(By.css('body'));
-      let first = await driver.findElement(By.css('#first'));
-      let last = await driver.findElement(By.css('#last'));
-      await first.click();
-      await first.sendKeys(Key.ARROW_DOWN);
-      let actual = await driver.executeScript(`
-        return window.getComputedStyle(document.querySelector('#last')).outlineColor
-      `);
-      expect(actual).toEqual(FOCUS_RING_STYLE);
+    let body = await driver.findElement(By.css('body'));
+    let first = await driver.findElement(By.css('#first'));
+    let last = await driver.findElement(By.css('#last'));
+    await first.click();
+    await first.sendKeys(Key.ARROW_DOWN);
+    let actual = await driver.executeScript(`
+      return window.getComputedStyle(document.querySelector('#last')).outlineColor
+    `);
+    expect(actual).toEqual(FOCUS_RING_STYLE);
   });
 
   it('should NOT apply .focus-ring on mouse focus', async function() {
-      let body = await driver.findElement(By.css('body'));
-      let first = await driver.findElement(By.css('#first'));
-      await first.click();
-      let actual = await driver.executeScript(`
-        return window.getComputedStyle(document.querySelector('#first')).outlineColor
-      `);
-      expect(actual).toNotEqual(FOCUS_RING_STYLE);
+    let body = await driver.findElement(By.css('body'));
+    let first = await driver.findElement(By.css('#first'));
+    await first.click();
+    let actual = await driver.executeScript(`
+      return window.getComputedStyle(document.querySelector('#first')).outlineColor
+    `);
+    expect(actual).toNotEqual(FOCUS_RING_STYLE);
   });
 
 });

--- a/test/specs/input-radio-group.js
+++ b/test/specs/input-radio-group.js
@@ -1,0 +1,33 @@
+const {fixture, matchesKeyboard, matchesMouse, FOCUS_RING_STYLE} = require('./helpers');
+const {Key, By} = require('selenium-webdriver');
+const expect = require('expect');
+const driver = global.__driver;
+
+describe('<input type="radio"> group', function() {
+  beforeEach(function() {
+    return fixture('input-radio-group.html');
+  });
+
+  it('should apply .focus-ring on keyboard focus', async function() {
+      let body = await driver.findElement(By.css('body'));
+      let first = await driver.findElement(By.css('#first'));
+      let last = await driver.findElement(By.css('#last'));
+      await first.click();
+      await first.sendKeys(Key.ARROW_DOWN);
+      let actual = await driver.executeScript(`
+        return window.getComputedStyle(document.querySelector('#last')).outlineColor
+      `);
+      expect(actual).toEqual(FOCUS_RING_STYLE);
+  });
+
+  it('should NOT apply .focus-ring on mouse focus', async function() {
+      let body = await driver.findElement(By.css('body'));
+      let first = await driver.findElement(By.css('#first'));
+      await first.click();
+      let actual = await driver.executeScript(`
+        return window.getComputedStyle(document.querySelector('#first')).outlineColor
+      `);
+      expect(actual).toNotEqual(FOCUS_RING_STYLE);
+  });
+
+});

--- a/test/specs/input-submit.js
+++ b/test/specs/input-submit.js
@@ -9,7 +9,7 @@ describe('<input type="submit">', function() {
     return matchesKeyboard();
   });
 
-  it.skip('should NOT apply .focus-ring on mouse focus', function() {
+  it('should NOT apply .focus-ring on mouse focus', function() {
     return matchesMouse(false);
   });
 });


### PR DESCRIPTION
This reverts the behavior that's currently on master because it was breaking mouse focus and causing most of the tests to fail. It uses a different approach to address the URL bar issue from #15 and adds support for arrow keys to address #54, #63.

This also removes the polyfill for classList. This is in accordance with the W3C's new [Polyfill guidance](https://www.w3.org/2001/tag/doc/polyfills/#don-t-serve-unnecessary-polyfills) which suggests that polyfills should not bundle other polyfills. Instead, we'll update our docs to mention that the polyfill depends on classList and users should use a service like polyfill.io to add it.

@kloots FYI because I needed to back out the previous `onKeyUp` change.