### PR TITLE
Begrudgingly add eslint back

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,11 @@
+module.exports = {
+  env: {
+    browser: true
+  },
+  // The only thing we want ESLint to do is yell at us if we accidentally use ES2015+.
+  // This is because we don't want/need to use Babel in this project.
+  // We specifically DO NOT want ESLint to try to enforce a style guide on us.
+  // We user prettier for that.
+  extends: ['prettier'],
+  plugins: ['es5']
+};

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
       "npm run build && concurrently -k \"npm run test:server\" \"npm run test:selenium\""
   },
   "lint-staged": {
+    "src/focus-ring.js": ["eslint"],
     "*.{js,json,css}": ["prettier --write", "git add"]
   },
   "main": "dist/focus-ring.js",
@@ -29,6 +30,9 @@
     "chromedriver": "2.33.2",
     "clear-module": "2.1.0",
     "concurrently": "3.5.0",
+    "eslint": "4.11.0",
+    "eslint-config-prettier": "2.7.0",
+    "eslint-plugin-es5": "1.1.0",
     "expect": "1.20.2",
     "geckodriver": "1.10.0",
     "glob-promise": "3.3.0",


### PR DESCRIPTION
@alice PTAL.

I really dislike ESLint because it mixes style guide enforcement with error checking and is super wonky to configure.

Having said that, as soon as I published v3.0 [someone pointed out](https://github.com/WICG/focus-ring/issues/76) that I had snuck an untranspiled `const` in there.

This PR adds ESLint back but scopes it to only lint the `src/focus-ring.js` file, and to only check that we're not using ES2015 features. It does not try to do style guide enforcement via ESLint (instead it defers to Prettier). Finally, the PR adds a precommit hook to run ESLint against any file changes to `src/focus-ring.js` and bail if it fails.